### PR TITLE
gpt-4o-miniの追加

### DIFF
--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -18,6 +18,7 @@ Carefully heed the user's instructions.
 Respond in Japanese using Markdown.`;
 
 export const modelOptions: ModelOptions[] = [
+  'gpt-4o-mini',
   'gpt-3.5-turbo',
   // 'gpt-3.5-turbo-16k',
   // 'gpt-3.5-turbo-1106',
@@ -35,7 +36,7 @@ export const modelOptions: ModelOptions[] = [
   // 'gpt-4-32k-0314',
 ];
 
-export const defaultModel = 'gpt-3.5-turbo';
+export const defaultModel = 'gpt-4o-mini';
 
 export const modelMaxToken = {
   'gpt-3.5-turbo': 4096,
@@ -57,6 +58,7 @@ export const modelMaxToken = {
   'gpt-4-turbo-2024-04-09': 128000,
   'gpt-4o': 128000,
   'gpt-4o-2024-05-13': 128000,
+  'gpt-4o-mini': 128000,
 };
 
 export const modelCost = {
@@ -136,6 +138,10 @@ export const modelCost = {
     prompt: { price: 0.005, unit: 1000 },
     completion: { price: 0.015, unit: 1000 },
   },
+  'gpt-4o-mini' : {
+    prompt: { price: 0.00015, unit: 1000 },
+    completion: { price: 0.0006, unit: 1000 },
+  }
 };
 
 export const defaultUserMaxToken = 4000;

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -50,6 +50,7 @@ export interface Folder {
 }
 
 export type ModelOptions =
+  | 'gpt-4o-mini'
   | 'gpt-4o'
   | 'gpt-4o-2024-05-13'
   | 'gpt-4'


### PR DESCRIPTION
# 概要
GPT-4o miniの設定を追加しました。

設定値は下記公式ページを参照
https://openai.com/api/pricing/#:~:text=a%20new%20window)-,GPT%2D4o%20mini,-GPT%2D4o%20mini
https://platform.openai.com/docs/models/gpt-4o-mini

併せて、GPT-3.5 Turboより安いということで、デフォルトモデルに設定しました。

# 動作確認
デフォルトチャットが変更されていることを確認しました。
![2024-07-19_14h25_36](https://github.com/user-attachments/assets/abfe06b5-df1e-4474-b065-feea459daac8)

gpt-4o-miniがモデルとして選択された場合に、GPT-4o miniでやり取りが行われていることを確認しました。
![2024-07-19_14h31_23](https://github.com/user-attachments/assets/a2e6ff72-b64f-48af-8f40-68a33da3bbf7)

開発者ツールからリクエストを確認し、正常にgpt-4o-miniがモデルとして送られ、レスポンスが返ってきていることを確認しました。
![2024-07-19_14h29_54](https://github.com/user-attachments/assets/27680ea1-9d0d-4b72-9f64-6fd82307c6fb)
![2024-07-19_14h30_21](https://github.com/user-attachments/assets/b424f9f6-d58f-457b-ae6c-3f0a36b90250)

# 質問
GPT-3.5 Turboを使えなくする必要はあるのでしょうか（現状は何もしていないです。）