### PR TITLE
モデルo3-miniの追加

### DIFF
--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -18,8 +18,10 @@ Carefully heed the user's instructions.
 Respond in Japanese using Markdown.`;
 
 export const modelOptions: ModelOptions[] = [
-  'o3-mini',
   'gpt-4o-mini',
+  'o3-mini',
+  'gpt-4o',
+  'gpt-4-turbo',
   'gpt-3.5-turbo',
   // 'gpt-3.5-turbo-16k',
   // 'gpt-3.5-turbo-1106',
@@ -28,9 +30,7 @@ export const modelOptions: ModelOptions[] = [
   // 'gpt-4-32k',
   // 'gpt-4-1106-preview',
   // 'gpt-4-0125-preview',
-  'gpt-4-turbo',
   // 'gpt-4-turbo-2024-04-09',
-  'gpt-4o',
   // 'gpt-4o-2024-05-13',
   // 'gpt-3.5-turbo-0301',
   // 'gpt-4-0314',

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -18,6 +18,7 @@ Carefully heed the user's instructions.
 Respond in Japanese using Markdown.`;
 
 export const modelOptions: ModelOptions[] = [
+  'o3-mini',
   'gpt-4o-mini',
   'gpt-3.5-turbo',
   // 'gpt-3.5-turbo-16k',
@@ -59,6 +60,7 @@ export const modelMaxToken = {
   'gpt-4o': 128000,
   'gpt-4o-2024-05-13': 128000,
   'gpt-4o-mini': 128000,
+  'o3-mini': 200000,
 };
 
 export const modelCost = {
@@ -141,6 +143,10 @@ export const modelCost = {
   'gpt-4o-mini' : {
     prompt: { price: 0.00015, unit: 1000 },
     completion: { price: 0.0006, unit: 1000 },
+  },
+  'o3-mini' : {
+    prompt: { price: 0.00110, unit: 1000 },
+    completion: { price: 0.00440, unit: 1000 },
   }
 };
 

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -50,6 +50,7 @@ export interface Folder {
 }
 
 export type ModelOptions =
+  | 'o3-mini'
   | 'gpt-4o-mini'
   | 'gpt-4o'
   | 'gpt-4o-2024-05-13'


### PR DESCRIPTION
@beyondmandai 
# 概要
o3-miniの設定を追加しました。

設定値は下記公式ページを参照
https://openai.com/api/pricing/#:~:text=a%20new%20window)-,OpenAI%20o3%2Dmini,-o3%2Dmini%20is
https://platform.openai.com/docs/models#o3-mini

デフォルトモデルは引き続き4o-miniに設定しております。

# 動作確認
o3-miniが追加されていることを確認しました。
![2025-02-03_18h26_19](https://github.com/user-attachments/assets/ad7341a9-2020-452f-807d-b14b99f42a26)
o3-miniがモデルとして選択された場合に、o3-miniでやり取りが行われていることを確認しました。
![2025-02-03_18h13_42](https://github.com/user-attachments/assets/125e175a-d01c-4d0e-a0c8-a5bfd99d71a1)

# 余談
本家はもうほぼほぼ動いていないので、そのうち他に乗り換えも検討ですかね？
参考：メンテされている派生
https://github.com/animalnots/BetterChatGPT-PLUS