### PR TITLE
deprecatedになったアクションの更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,10 +37,13 @@ jobs:
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.GCLIENT }}
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
+          name: page-artifact
           path: './dist'
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
+        with:
+          artifact-name: page-artifact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
@@ -37,13 +37,10 @@ jobs:
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.GCLIENT }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: page-artifact
           path: './dist'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
-        with:
-          artifact-name: page-artifact
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
@beyondmandai 
お疲れ様です。

Github Pagesへのデプロイが失敗していたので、workflowを修正しました。

#失敗要因
workflow内で使われているアクションがdeprecatedになったため
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

#更新内容
* Updated `actions/checkout` from version 3 to version 4. (.github/workflows/deploy.yml)
* Updated `actions/setup-node` from version 3 to version 4. (.github/workflows/deploy.yml)
* Updated `actions/upload-pages-artifact` from version 1 to version 3. (.github/workflows/deploy.yml)
* Updated `actions/deploy-pages` from version 1 to version 4. (.github/workflows/deploy.yml)

#動作確認
forkしたリポジトリにてアクションを実行し、正常にPagesへデプロイされたことを確認しました。
![2025-02-05_13h35_47](https://github.com/user-attachments/assets/05ed1024-8480-4cab-b085-02fd38e2193e)
![2025-02-05_13h35_19](https://github.com/user-attachments/assets/66ee4478-a1bb-4f19-8d28-5bbdade663f4)

次回以降は自分の方でActions動作確認してからプルリクを作成するようにします。
お手数をおかけしますが、ご確認の程をよろしくお願いいたします。
