### PR TITLE
現在利用できないモデルが選択されている場合に、デフォルトモデルに自動的に切り替える

### DIFF
--- a/public/locales/de/api.json
+++ b/public/locales/de/api.json
@@ -11,5 +11,6 @@
   },
   "customEndpoint": "Verwende einen benutzerdefinierten API-Endpunkt",
   "advancedConfig": "Sieh dir die <0>erweiterten API Konfigurationen</0> an",
-  "noApiKeyWarning": "Kein API-Schlüssel angegeben! Überprüfe bitte deine API-Einstellungen."
+  "noApiKeyWarning": "Kein API-Schlüssel angegeben! Überprüfe bitte deine API-Einstellungen.",
+  "invalidModelFallback": "Ungültiges Modell erkannt. Automatisch zu {{model}} gewechselt."
 }

--- a/public/locales/en/api.json
+++ b/public/locales/en/api.json
@@ -11,5 +11,6 @@
   },
   "customEndpoint": "Use custom API endpoint",
   "advancedConfig": "View advanced API configuration <0>here</0>",
-  "noApiKeyWarning": "No API key supplied! Please check your API settings."
+  "noApiKeyWarning": "No API key supplied! Please check your API settings.",
+  "invalidModelFallback": "Invalid model detected. Switched to {{model}} automatically."
 }

--- a/public/locales/es/api.json
+++ b/public/locales/es/api.json
@@ -12,5 +12,6 @@
   },
   "customEndpoint": "Usar un punto final de acceso personalizado",
   "advancedConfig": "Ver configuración avanzada de API <0>aquí</0>",
-  "noApiKeyWarning": "¡No se proporcionó clave de API! Por favor, revisa tus ajustes de API."
+  "noApiKeyWarning": "¡No se proporcionó clave de API! Por favor, revisa tus ajustes de API.",
+  "invalidModelFallback": "Modelo inválido detectado. Cambiado automáticamente a {{model}}."
 }

--- a/public/locales/fr/api.json
+++ b/public/locales/fr/api.json
@@ -11,5 +11,6 @@
   },
   "customEndpoint": "Utiliser un point d'accès personnalisé à l'API",
   "advancedConfig": "Voir la configuration avancée de l'API <0>ici</0>",
-  "noApiKeyWarning": "Aucune clé API fournie ! Veuillez vérifier vos paramètres d'API."
+  "noApiKeyWarning": "Aucune clé API fournie ! Veuillez vérifier vos paramètres d'API.",
+  "invalidModelFallback": "Modèle invalide détecté. Basculé automatiquement vers {{model}}."
 }

--- a/public/locales/ja/api.json
+++ b/public/locales/ja/api.json
@@ -11,5 +11,6 @@
   },
   "customEndpoint": "カスタムAPIエンドポイントを使用する",
   "advancedConfig": "詳細なAPI設定は<0>こちら</0>で表示できます。",
-  "noApiKeyWarning": "APIキーが入力されていません！API設定を確認してください。"
+  "noApiKeyWarning": "APIキーが入力されていません！API設定を確認してください。",
+  "invalidModelFallback": "無効なモデルが検出されました。自動的に{{model}}に切り替えました。"
 }

--- a/public/locales/zh-CN/api.json
+++ b/public/locales/zh-CN/api.json
@@ -11,5 +11,6 @@
   },
   "customEndpoint": "使用自定义 API 端点",
   "advancedConfig": "在<0>此处</0>查看进阶 API 设置",
-  "noApiKeyWarning": "缺少 API key，请检查 API 设置。"
+  "noApiKeyWarning": "缺少 API key，请检查 API 设置。",
+  "invalidModelFallback": "检测到无效模型。已自动切换到 {{model}}。"
 }

--- a/public/locales/zh-TW/api.json
+++ b/public/locales/zh-TW/api.json
@@ -11,5 +11,6 @@
   },
   "customEndpoint": "使用自訂 API 端點",
   "advancedConfig": "在<0>此處</0>檢視進階 API 設定",
-  "noApiKeyWarning": "未提供 API 金鑰！請檢查 API 設定。"
+  "noApiKeyWarning": "未提供 API 金鑰！請檢查 API 設定。",
+  "invalidModelFallback": "偵測到無效模型。已自動切換至 {{model}}。"
 }

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -25,7 +25,7 @@ const Toast = () => {
 
   return toastShow ? (
     <div
-      className={`flex fixed right-5 bottom-5 z-[1000] items-center w-3/4 md:w-full max-w-xs p-4 mb-4 text-gray-500 dark:text-gray-400 rounded-lg shadow-md border border-gray-400/30 animate-bounce`}
+      className={`flex fixed right-5 bottom-20 z-[1000] items-center w-3/4 md:w-full max-w-xs p-4 mb-4 text-gray-500 dark:text-gray-400 rounded-lg shadow-md border border-gray-400/30 animate-bounce`}
       role='alert'
     >
       <StatusIcon status={status} />

--- a/src/hooks/useSubmit.ts
+++ b/src/hooks/useSubmit.ts
@@ -1,11 +1,11 @@
 import React from 'react';
 import useStore from '@store/store';
 import { useTranslation } from 'react-i18next';
-import { ChatInterface, MessageInterface } from '@type/chat';
+import { ChatInterface, MessageInterface, ModelOptions } from '@type/chat';
 import { getChatCompletion, getChatCompletionStream } from '@api/api';
 import { parseEventSource } from '@api/helper';
 import { limitMessageTokens, updateTotalTokenUsed } from '@utils/messageUtils';
-import { _defaultChatConfig } from '@constants/chat';
+import { _defaultChatConfig, defaultModel, modelOptions } from '@constants/chat';
 import { officialAPIEndpoint } from '@constants/auth';
 
 const useSubmit = () => {
@@ -18,6 +18,9 @@ const useSubmit = () => {
   const generating = useStore((state) => state.generating);
   const currentChatIndex = useStore((state) => state.currentChatIndex);
   const setChats = useStore((state) => state.setChats);
+  const setToastShow = useStore((state) => state.setToastShow);
+  const setToastMessage = useStore((state) => state.setToastMessage);
+  const setToastStatus = useStore((state) => state.setToastStatus);
 
   const generateTitle = async (
     message: MessageInterface[]
@@ -55,7 +58,24 @@ const useSubmit = () => {
     const chats = useStore.getState().chats;
     if (generating || !chats) return;
 
-    const updatedChats: ChatInterface[] = JSON.parse(JSON.stringify(chats));
+    // Check if current model is valid, if not switch to default model
+    const currentModel = chats[currentChatIndex].config.model;
+    if (!modelOptions.includes(currentModel)) {
+      const updatedChatsWithValidModel: ChatInterface[] = JSON.parse(JSON.stringify(chats));
+      updatedChatsWithValidModel[currentChatIndex].config.model = defaultModel as ModelOptions;
+      setChats(updatedChatsWithValidModel);
+      
+      // Show toast notification about model change
+      setToastMessage(`Invalid model detected. Switched to ${defaultModel} automatically.`);
+      setToastStatus('warning');
+      setToastShow(true);
+    }
+
+    // Get updated chats after potential model change
+    const currentChats = useStore.getState().chats;
+    if (!currentChats) return;
+    
+    const updatedChats: ChatInterface[] = JSON.parse(JSON.stringify(currentChats));
 
     updatedChats[currentChatIndex].messages.push({
       role: 'assistant',
@@ -67,13 +87,13 @@ const useSubmit = () => {
 
     try {
       let stream;
-      if (chats[currentChatIndex].messages.length === 0)
+      if (currentChats[currentChatIndex].messages.length === 0)
         throw new Error('No messages submitted!');
 
       const messages = limitMessageTokens(
-        chats[currentChatIndex].messages,
-        chats[currentChatIndex].config.max_tokens,
-        chats[currentChatIndex].config.model
+        currentChats[currentChatIndex].messages,
+        currentChats[currentChatIndex].config.max_tokens,
+        currentChats[currentChatIndex].config.model
       );
       if (messages.length === 0) throw new Error('Message exceed max token!');
 
@@ -88,14 +108,14 @@ const useSubmit = () => {
         stream = await getChatCompletionStream(
           useStore.getState().apiEndpoint,
           messages,
-          chats[currentChatIndex].config
+          currentChats[currentChatIndex].config
         );
       } else if (apiKey) {
         // own apikey
         stream = await getChatCompletionStream(
           useStore.getState().apiEndpoint,
           messages,
-          chats[currentChatIndex].config,
+          currentChats[currentChatIndex].config,
           apiKey
         );
       }

--- a/src/hooks/useSubmit.ts
+++ b/src/hooks/useSubmit.ts
@@ -66,7 +66,7 @@ const useSubmit = () => {
       setChats(updatedChatsWithValidModel);
       
       // Show toast notification about model change
-      setToastMessage(`Invalid model detected. Switched to ${defaultModel} automatically.`);
+      setToastMessage(t('invalidModelFallback', { model: defaultModel }));
       setToastStatus('warning');
       setToastShow(true);
     }


### PR DESCRIPTION
#概要
ユーザからの入力がが送られた際に、以下の挙動を取るように処理を調整しました。
* 現在利用できないモデルかを確認
* 利用できない場合は、デフォルトモデルに変更
* 変更したことをユーザに知らせるトーストメッセージを表示

# 動作確認
実行前、o3-miniを設定したチャットを準備し、無効化
![2025-06-18_14h55_13](https://github.com/user-attachments/assets/313dc474-074b-4404-83f6-edbfb3ab6dbc)
送信したところ、右下にトーストメッセージが表示
![2025-06-18_15h15_22](https://github.com/user-attachments/assets/99782944-f80e-43cc-a9df-a3bd0809c3d7)
リクエストもデフォルトの4o-miniで表示されていることを確認
![2025-06-18_14h55_43](https://github.com/user-attachments/assets/e6aa852e-938c-4916-b9e4-5bc4cbe25d4b)

#備考
今回のコードは、CUI コーディングエージェントのClaude Codeに調整してもらいました。
https://dev.classmethod.jp/articles/get-started-claude-code-1/