### PR TITLE
gpt-4.1-nano と o3 の追加

### DIFF
--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -18,11 +18,13 @@ Carefully heed the user's instructions.
 Respond in Japanese using Markdown.`;
 
 export const modelOptions: ModelOptions[] = [
-  'gpt-4o-mini',
-  'o3-mini',
-  'gpt-4o',
-  'gpt-4-turbo',
-  'gpt-3.5-turbo',
+  'gpt-4.1-nano',
+  'o3',
+  // 'gpt-4o-mini',
+  // 'o3-mini',
+  // 'gpt-4o',
+  // 'gpt-4-turbo',
+  // 'gpt-3.5-turbo',
   // 'gpt-3.5-turbo-16k',
   // 'gpt-3.5-turbo-1106',
   // 'gpt-3.5-turbo-0125',
@@ -37,7 +39,7 @@ export const modelOptions: ModelOptions[] = [
   // 'gpt-4-32k-0314',
 ];
 
-export const defaultModel = 'gpt-4o-mini';
+export const defaultModel = 'gpt-4.1-nano';
 
 export const modelMaxToken = {
   'gpt-3.5-turbo': 4096,
@@ -61,6 +63,8 @@ export const modelMaxToken = {
   'gpt-4o-2024-05-13': 128000,
   'gpt-4o-mini': 128000,
   'o3-mini': 200000,
+  'gpt-4.1-nano': 128000,
+  'o3': 200000,
 };
 
 export const modelCost = {
@@ -147,6 +151,14 @@ export const modelCost = {
   'o3-mini' : {
     prompt: { price: 0.00110, unit: 1000 },
     completion: { price: 0.00440, unit: 1000 },
+  },
+  'gpt-4.1-nano': {
+    prompt: { price: 0.0001, unit: 1000 },
+    completion: { price: 0.0004, unit: 1000 },
+  },
+  'o3': {
+    prompt: { price: 0.0020, unit: 1000 },
+    completion: { price: 0.0080, unit: 1000 },
   }
 };
 

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -50,23 +50,8 @@ export interface Folder {
 }
 
 export type ModelOptions =
-  | 'o3-mini'
-  | 'gpt-4o-mini'
-  | 'gpt-4o'
-  | 'gpt-4o-2024-05-13'
-  | 'gpt-4'
-  | 'gpt-4-32k'
-  | 'gpt-4-1106-preview'
-  | 'gpt-4-0125-preview'
-  | 'gpt-4-turbo'
-  | 'gpt-4-turbo-2024-04-09'
-  | 'gpt-3.5-turbo'
-  | 'gpt-3.5-turbo-16k'
-  | 'gpt-3.5-turbo-1106'
-  | 'gpt-3.5-turbo-0125';
-// | 'gpt-3.5-turbo-0301';
-// | 'gpt-4-0314'
-// | 'gpt-4-32k-0314'
+  | 'gpt-4.1-nano'
+  | 'o3';
 
 export type TotalTokenUsed = {
   [model in ModelOptions]?: {


### PR DESCRIPTION
@beyondmandai 
# 概要
モデルの追加を行いました。
4.1 nanoをデフォルト、reasoningモデルとしてo3 を設定しています。
https://www.chatwork.com/#!rid173737111-1987008418598227968

# 動作確認
4.1 nano は問題なく叩けました。
![2025-06-18_19h46_24](https://github.com/user-attachments/assets/d52367b7-df34-4182-aedf-a425da546b8a)
o3を叩こうとしたところ、下記エラーが出ました。
![2025-06-18_19h44_42](https://github.com/user-attachments/assets/8fc59584-d11b-492a-aa72-c3bbab18a77b)

```
{
  "error": {
    "message": "Your organization must be verified to stream this model. Please go to: https://platform.openai.com/settings/organization/general and click on Verify Organization. If you just verified, it can take up to 15 minutes for access to propagate.",
    "type": "invalid_request_error",
    "param": "stream",
    "code": "unsupported_value"
  }
}
```

こちら、萬代さんの方で認証を進めていただくことは可能でしょうか。
https://zenn.dev/schroneko/articles/openai-verify-organization

ご確認とご対応をよろしくお願いいたします。