### PR TITLE
モデルの更新(gpt-5)

### DIFF
--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -40,7 +40,7 @@ export const modelOptions: ModelOptions[] = [
   // 'gpt-4-32k-0314',
 ];
 
-export const defaultModel = 'gpt-5-mini';
+export const defaultModel = 'gpt-5-nano';
 
 export const modelMaxToken = {
   'gpt-5.4': 1050000,

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -43,9 +43,9 @@ export const modelOptions: ModelOptions[] = [
 export const defaultModel = 'gpt-5-mini';
 
 export const modelMaxToken = {
-  'gpt-5.4': 200000,
-  'gpt-5-mini': 128000,
-  'gpt-5-nano': 128000,
+  'gpt-5.4': 1050000,
+  'gpt-5-mini': 400000,
+  'gpt-5-nano': 400000,
   'gpt-3.5-turbo': 4096,
   'gpt-3.5-turbo-0301': 4096,
   'gpt-3.5-turbo-0613': 4096,
@@ -71,15 +71,15 @@ export const modelMaxToken = {
 
 export const modelCost = {
   'gpt-5.4': {
-    prompt: { price: 0.01, unit: 1000 },
-    completion: { price: 0.03, unit: 1000 },
+    prompt: { price: 0.0025, unit: 1000 },
+    completion: { price: 0.015, unit: 1000 },
   },
   'gpt-5-mini': {
-    prompt: { price: 0.00015, unit: 1000 },
-    completion: { price: 0.0006, unit: 1000 },
+    prompt: { price: 0.00025, unit: 1000 },
+    completion: { price: 0.002, unit: 1000 },
   },
   'gpt-5-nano': {
-    prompt: { price: 0.0001, unit: 1000 },
+    prompt: { price: 0.00005, unit: 1000 },
     completion: { price: 0.0004, unit: 1000 },
   },
   'gpt-3.5-turbo': {

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -18,7 +18,7 @@ Carefully heed the user's instructions.
 Respond in Japanese using Markdown.`;
 
 export const modelOptions: ModelOptions[] = [
-  'gpt-5.4',
+  'gpt-5.5',
   'gpt-5-mini',
   'gpt-5-nano',
   // 'gpt-4o-mini',
@@ -43,7 +43,7 @@ export const modelOptions: ModelOptions[] = [
 export const defaultModel = 'gpt-5-nano';
 
 export const modelMaxToken = {
-  'gpt-5.4': 1050000,
+  'gpt-5.5': 1050000,
   'gpt-5-mini': 400000,
   'gpt-5-nano': 400000,
   'gpt-3.5-turbo': 4096,
@@ -70,9 +70,9 @@ export const modelMaxToken = {
 };
 
 export const modelCost = {
-  'gpt-5.4': {
-    prompt: { price: 2.50, unit: 1000000 },
-    completion: { price: 15.00, unit: 1000000 },
+  'gpt-5.5': {
+    prompt: { price: 5.00, unit: 1000000 },
+    completion: { price: 30.00, unit: 1000000 },
   },
   'gpt-5-mini': {
     prompt: { price: 0.25, unit: 1000000 },

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -71,16 +71,16 @@ export const modelMaxToken = {
 
 export const modelCost = {
   'gpt-5.4': {
-    prompt: { price: 0.0025, unit: 1000 },
-    completion: { price: 0.015, unit: 1000 },
+    prompt: { price: 2.50, unit: 1000000 },
+    completion: { price: 15.00, unit: 1000000 },
   },
   'gpt-5-mini': {
-    prompt: { price: 0.00025, unit: 1000 },
-    completion: { price: 0.002, unit: 1000 },
+    prompt: { price: 0.25, unit: 1000000 },
+    completion: { price: 2.00, unit: 1000000 },
   },
   'gpt-5-nano': {
-    prompt: { price: 0.00005, unit: 1000 },
-    completion: { price: 0.0004, unit: 1000 },
+    prompt: { price: 0.05, unit: 1000000 },
+    completion: { price: 0.40, unit: 1000000 },
   },
   'gpt-3.5-turbo': {
     prompt: { price: 0.0015, unit: 1000 },
@@ -168,7 +168,7 @@ export const modelCost = {
   }
 };
 
-export const defaultUserMaxToken = 4000;
+export const defaultUserMaxToken = 16000;
 
 export const _defaultChatConfig: ConfigInterface = {
   model: defaultModel,

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -18,11 +18,14 @@ Carefully heed the user's instructions.
 Respond in Japanese using Markdown.`;
 
 export const modelOptions: ModelOptions[] = [
-  'gpt-4o-mini',
-  'o3-mini',
-  'gpt-4o',
-  'gpt-4-turbo',
-  'gpt-3.5-turbo',
+  'gpt-5.4',
+  'gpt-5-mini',
+  'gpt-5-nano',
+  // 'gpt-4o-mini',
+  // 'o3-mini',
+  // 'gpt-4o',
+  // 'gpt-4-turbo',
+  // 'gpt-3.5-turbo',
   // 'gpt-3.5-turbo-16k',
   // 'gpt-3.5-turbo-1106',
   // 'gpt-3.5-turbo-0125',
@@ -37,9 +40,12 @@ export const modelOptions: ModelOptions[] = [
   // 'gpt-4-32k-0314',
 ];
 
-export const defaultModel = 'gpt-4o-mini';
+export const defaultModel = 'gpt-5-mini';
 
 export const modelMaxToken = {
+  'gpt-5.4': 200000,
+  'gpt-5-mini': 128000,
+  'gpt-5-nano': 128000,
   'gpt-3.5-turbo': 4096,
   'gpt-3.5-turbo-0301': 4096,
   'gpt-3.5-turbo-0613': 4096,
@@ -64,6 +70,18 @@ export const modelMaxToken = {
 };
 
 export const modelCost = {
+  'gpt-5.4': {
+    prompt: { price: 0.01, unit: 1000 },
+    completion: { price: 0.03, unit: 1000 },
+  },
+  'gpt-5-mini': {
+    prompt: { price: 0.00015, unit: 1000 },
+    completion: { price: 0.0006, unit: 1000 },
+  },
+  'gpt-5-nano': {
+    prompt: { price: 0.0001, unit: 1000 },
+    completion: { price: 0.0004, unit: 1000 },
+  },
   'gpt-3.5-turbo': {
     prompt: { price: 0.0015, unit: 1000 },
     completion: { price: 0.002, unit: 1000 },

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -50,7 +50,7 @@ export interface Folder {
 }
 
 export type ModelOptions =
-  | 'gpt-5.4'
+  | 'gpt-5.5'
   | 'gpt-5-mini'
   | 'gpt-5-nano'
   | 'o3-mini'

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -50,6 +50,9 @@ export interface Folder {
 }
 
 export type ModelOptions =
+  | 'gpt-5.4'
+  | 'gpt-5-mini'
+  | 'gpt-5-nano'
   | 'o3-mini'
   | 'gpt-4o-mini'
   | 'gpt-4o'


### PR DESCRIPTION
@beyondmandai 
# 概要
モデルの更新を行いました。
gpt-5-nanoをデフォルト、reasoningモデルとして gpt-5.5 を設定しています。

# 動作確認
各モデル問題なく叩けました。
<img width="814" height="244" alt="2026-06-08_16h25_21" src="https://github.com/user-attachments/assets/f32ed0d6-50fb-46ad-bb73-2dec732ececb" />
<img width="803" height="238" alt="2026-06-08_16h26_39" src="https://github.com/user-attachments/assets/5d3669f7-b9a1-4eac-a0ef-4ee5cd79b995" />
<img width="810" height="243" alt="2026-06-08_16h27_28" src="https://github.com/user-attachments/assets/fe6e91fa-f7c2-4f34-ac70-c5cf08872828" />

# 備考
https://github.com/beyond-development/byd-BetterChatGPT/pull/6
上記プルリクのマージもお手数ですがお願いいたします。（マージの権限が自分にないため）

ご確認とご対応をよろしくお願いいたします。